### PR TITLE
Уже загружен

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -65,7 +65,8 @@
     function loadAddin(loaderStr, group) {
         //Message("Load " + loaderStr);
         if (!addins.loadAddin(loaderStr, group)) {
-            Message("Ошибка загрузки аддина '" + loaderStr + "': " + addins.lastAddinError);
+            if (!(addins.lastAddinError.substr(addins.lastAddinError.length-12) === "уже загружен"))
+                Message("Ошибка загрузки аддина '" + loaderStr + "': " + addins.lastAddinError);
             return false;
         }
         return true;


### PR DESCRIPTION
Выводим всё, что не заканчивается на "уже загружен"

Зачастую скрипты грузят другие скрипты и видеть при старте кучу сообщений, что скрипт "УЖЕ ЗАГРУЖЕН" смысла мало.
Убран вывод только таких сообщений и только при старте.

@infostart-hub/snegopat - просьба прокомментировать и проверить
