### PR TITLE
Автоподключение к хранилищам расширений и поправлен вылет, если диалог, на который хук поставлен, не содержит view

### DIFF
--- a/addins/stg_autoconnect.js
+++ b/addins/stg_autoconnect.js
@@ -47,110 +47,115 @@ function cnnString()
 
 var count = 0;
 
-function doAutoConnect(dlgInfo, matches)
+function doAutoConnectToStorage(dlgInfo)
 {
-	repoTitle = matches[2];
-	repoParam = "Конфигурация";
+	var matches = dlgInfo.caption.match(/^(Соединение с хранилищем )(конфигурации|расширения )(.*)/i);
 	
-	if (!(matches[2]=="конфигурации"))
+	if (matches && matches.length && matches[2])
 	{
-		repoTitle = repoTitle + matches[3];
-		repoParam = "Расширение:"+matches[3];
-	}
-
-	if (count > 16) {
-			prevConnectSuccessed = true;
-			count = 0;
-	}
-
-	if (dlgInfo.stage == afterInitial)
-	{
-
-		count++;
-
-		if (prevCaption == repoTitle)//не удалось авторизоваться
+		repoTitle = matches[2];
+		repoParam = "Конфигурация";
+		
+		if (!(matches[2]=="конфигурации"))
 		{
-			prevConnectSuccessed = false
-		}
-		else
-		{
-			prevCaption = repoTitle;
-			prevConnectSuccessed = true;
+			repoTitle = repoTitle + matches[3];
+			repoParam = "Расширение:"+matches[3];
 		}
 
-		var data0 = profileRoot.getValue(pflData);
-		if (!(data0))
-			data0 = v8New("Соответствие");
-		var data = data0.Получить(repoParam);
-		if(data)
-		{
-			if (!prevConnectSuccessed)
-			{
-				if(MessageBox("Авто-соединение с хранилищем "+repoTitle+" было неудачным. Сбросить сохраненные данные?", mbYesNo | mbDefButton1 | mbIconQuestion, "Снегопат") == mbaYes)
-				{
-					var data0 = profileRoot.getValue(pflData);
-					if (data0)
-						data0.Удалить(repoParam);
-				}
+		if (count > 16) {
 				prevConnectSuccessed = true;
+				count = 0;
+		}
+
+		if (dlgInfo.stage == afterInitial)
+		{
+
+			count++;
+
+			if (prevCaption == repoTitle)//не удалось авторизоваться
+			{
+				prevConnectSuccessed = false
 			}
 			else
 			{
-				var currentBasePath = profileRoot.getValue(pflCurrentBasePath);
-				if (!currentBasePath)
-					currentBasePath = cnnString();
-
-				if (currentBasePath.toLowerCase() != cnnString().toLowerCase()){
-					var questionStirng = " Для базы сохранена другая строка подключения. \n";
-					questionStirng += "Текущий путь:"+cnnString()+"\n";
-					questionStirng += "Сохраненный путь:"+currentBasePath+" \n";
-					questionStirng += "\t ВНИМАНИЕ ВОПРОС \n"+"Продолжить автоподключение?";
-					if(MessageBox( questionStirng, mbYesNo | mbDefButton1 | mbIconQuestion, "Авто-соединение к хранилищу "+repoTitle+" !") == mbaNo)
-						return;
-				}
-				// Если есть сохраненные данные, то вводим их
-				dlgInfo.form.getControl("UserName").value = data.login
-				dlgInfo.form.getControl("UserPassword").value = data.password
-				dlgInfo.form.getControl("DepotPath").value = data.path
-				dlgInfo.cancel = true   // Отменяем показ диалога
-				dlgInfo.result = 1      // Как будто в нем нажали Ок
-				if(profileRoot.getValue(pflShowMessage))    // Информируем пользователя, если он хочет
-					Message("Авто-подключение к хранилищу "+repoTitle+" '" + data.path + "' пользователем '" + data.login + "'")
+				prevCaption = repoTitle;
+				prevConnectSuccessed = true;
 			}
-		}
-	}
-	else if(dlgInfo.stage == afterDoModal && dlgInfo.result == 1 && dlgInfo.cancel == false)
-	{
-		// Предложим сохранить введенные данные
-		if(MessageBox("Подставлять введенные значения автоматически при последующих подключениях?",
-			mbYesNo | mbDefButton1 | mbIconQuestion) == mbaYes)
-		{
-			// Сохраним их
+
 			var data0 = profileRoot.getValue(pflData);
 			if (!(data0))
 				data0 = v8New("Соответствие");
-			var data = v8New("Структура", "login,password,path",
-				dlgInfo.form.getControl("UserName").value,
-				dlgInfo.form.getControl("UserPassword").value,
-				dlgInfo.form.getControl("DepotPath").value);
-			data0.Вставить(repoParam, data);
-			var currentBasePath = cnnString();
-			profileRoot.createValue(pflData, false, pflBaseUser)    // Храним отдельно для базы/пользователя
-			profileRoot.createValue(pflCurrentBasePath, false, pflBaseUser);
-			profileRoot.setValue(pflData, data0)
-			profileRoot.setValue(pflCurrentBasePath, currentBasePath)
+			var data = data0.Получить(repoParam);
+			if(data)
+			{
+				if (!prevConnectSuccessed)
+				{
+					if(MessageBox("Авто-соединение с хранилищем "+repoTitle+" было неудачным. Сбросить сохраненные данные?", mbYesNo | mbDefButton1 | mbIconQuestion, "Снегопат") == mbaYes)
+					{
+						var data0 = profileRoot.getValue(pflData);
+						if (data0)
+							data0.Удалить(repoParam);
+					}
+					prevConnectSuccessed = true;
+				}
+				else
+				{
+					var currentBasePath = profileRoot.getValue(pflCurrentBasePath);
+					if (!currentBasePath)
+						currentBasePath = cnnString();
+
+					if (currentBasePath.toLowerCase() != cnnString().toLowerCase()){
+						var questionStirng = " Для базы сохранена другая строка подключения. \n";
+						questionStirng += "Текущий путь:"+cnnString()+"\n";
+						questionStirng += "Сохраненный путь:"+currentBasePath+" \n";
+						questionStirng += "\t ВНИМАНИЕ ВОПРОС \n"+"Продолжить автоподключение?";
+						if(MessageBox( questionStirng, mbYesNo | mbDefButton1 | mbIconQuestion, "Авто-соединение к хранилищу "+repoTitle+" !") == mbaNo)
+							return;
+					}
+					// Если есть сохраненные данные, то вводим их
+					dlgInfo.form.getControl("UserName").value = data.login
+					dlgInfo.form.getControl("UserPassword").value = data.password
+					dlgInfo.form.getControl("DepotPath").value = data.path
+					dlgInfo.cancel = true   // Отменяем показ диалога
+					dlgInfo.result = 1      // Как будто в нем нажали Ок
+					if(profileRoot.getValue(pflShowMessage))    // Информируем пользователя, если он хочет
+						Message("Авто-подключение к хранилищу "+repoTitle+" '" + data.path + "' пользователем '" + data.login + "'")
+				}
+			}
 		}
+		else if(dlgInfo.stage == afterDoModal && dlgInfo.result == 1 && dlgInfo.cancel == false)
+		{
+			// Предложим сохранить введенные данные
+			if(MessageBox("Подставлять введенные значения автоматически при последующих подключениях?",
+				mbYesNo | mbDefButton1 | mbIconQuestion) == mbaYes)
+			{
+				// Сохраним их
+				var data0 = profileRoot.getValue(pflData);
+				if (!(data0))
+					data0 = v8New("Соответствие");
+				var data = v8New("Структура", "login,password,path",
+					dlgInfo.form.getControl("UserName").value,
+					dlgInfo.form.getControl("UserPassword").value,
+					dlgInfo.form.getControl("DepotPath").value);
+				data0.Вставить(repoParam, data);
+				var currentBasePath = cnnString();
+				profileRoot.createValue(pflData, false, pflBaseUser)    // Храним отдельно для базы/пользователя
+				profileRoot.createValue(pflCurrentBasePath, false, pflBaseUser);
+				profileRoot.setValue(pflData, data0)
+				profileRoot.setValue(pflCurrentBasePath, currentBasePath)
+			}
+		}
+		return true;
 	}
+	return false;
 }
 
 // Обработчик показа модальных окон.
 function onDoModal(dlgInfo)
 {
-    var matches = dlgInfo.caption.match(/^(Соединение с хранилищем )(конфигурации|расширения )(.*)/i);
-
-    if(matches && matches.length && matches[2])
+    if(doAutoConnectToStorage(dlgInfo))
     {
-		doAutoConnect(dlgInfo, matches);
+        return;
     }
     else if(dlgInfo.stage == openModalWnd && (dlgInfo.caption == "Захват объектов в хранилище конфигурации" ||
         dlgInfo.caption == "Помещение объектов в хранилище конфигурации"))

--- a/addins/stg_autoconnect.js
+++ b/addins/stg_autoconnect.js
@@ -25,7 +25,8 @@ var pflCurrentBasePath = pflPath + "CurrentBasePath"; // Храним путь �
 var pflAutoRecursiveCheckOut = pflPath + "AutoRecursiveCheckOut"; // Опция автоматической установки флажка "захватывать рекурсивно"
 var pflAutoOpenCfgStore = pflPath + "AutoOpenCfgStore";
 var pflCfgViewList = pflPath + "CfgViewList";
-var prevConnectSuccessed = true
+var prevConnectSuccessed = true;
+var prevCaption = "";
 
 // Настройку отображения сообщений будем хранить едино для всех баз, в профиле Снегопата
 profileRoot.createValue(pflShowMessage, true, pflSnegopat);
@@ -49,25 +50,55 @@ var count = 0;
 // Обработчик показа модальных окон.
 function onDoModal(dlgInfo)
 {
-    if(dlgInfo.caption == "Соединение с хранилищем конфигурации")
+    var matches = dlgInfo.caption.match(/^(Соединение с хранилищем )(конфигурации|расширения )(.*)/i);
+    var repoType = 0;
+    var repoTitle = "";
+    var repoParam = "";
+    if (matches && matches.length)
     {
-    	count++;
+        repoType = (matches[2]=="конфигурации")?1:2;
+        repoTitle = matches[2] + ((repoType==1)?"":matches[3]);
+        repoParam = (repoType==1)?"Конфигурация":("Расширение:"+matches[3]);
+        Message("Try:"+count+". Stage:"+dlgInfo.stage+". Title:"+repoTitle);
+    }
 
-    	if (count > 16) {
-		prevConnectSuccessed = true;
-                events.connect(Designer, "onIdle", SelfScript.self);
+    if(repoType)
+    {
+        if (count > 16) {
+                prevConnectSuccessed = true;
                 count = 0;
         }
 
-        if(dlgInfo.stage == beforeDoModal)
+        if (dlgInfo.stage == afterInitial)
         {
-            var data = profileRoot.getValue(pflData)
+
+            count++;
+
+            if (prevCaption == repoTitle)//не удалось авторизоваться
+            {
+                prevConnectSuccessed = false
+            }
+            else
+            {
+                prevCaption = repoTitle;
+                prevConnectSuccessed = true;
+            }
+
+            var data0 = profileRoot.getValue(pflData);
+            if (!(data0))
+                data0 = v8New("Соответствие");
+            var data = data0.Получить(repoParam);
             if(data)
             {
-                if(!prevConnectSuccessed)
+                if (!prevConnectSuccessed)
                 {
-                    if(MessageBox("Авто-соединение с хранилищем было неудачным. Сбросить сохраненные данные?", mbYesNo | mbDefButton1 | mbIconQuestion, "Снегопат") == mbaYes)
-                        profileRoot.deleteValue(pflData)
+                    if(MessageBox("Авто-соединение с хранилищем "+repoTitle+" было неудачным. Сбросить сохраненные данные?", mbYesNo | mbDefButton1 | mbIconQuestion, "Снегопат") == mbaYes)
+                    {
+                        var data0 = profileRoot.getValue(pflData);
+                        if (data0)
+                            data0.Удалить(repoParam);
+                    }
+                    prevConnectSuccessed = true;
                 }
                 else
                 {
@@ -80,7 +111,7 @@ function onDoModal(dlgInfo)
                         questionStirng += "Текущий путь:"+cnnString()+"\n";
                         questionStirng += "Сохраненный путь:"+currentBasePath+" \n";
                         questionStirng += "\t ВНИМАНИЕ ВОПРОС \n"+"Продолжить автоподключение?";
-                        if(MessageBox( questionStirng, mbYesNo | mbDefButton1 | mbIconQuestion, "Авто-соединение к хранилищу!") == mbaNo)
+                        if(MessageBox( questionStirng, mbYesNo | mbDefButton1 | mbIconQuestion, "Авто-соединение к хранилищу "+repoTitle+" !") == mbaNo)
                             return;
                     }
                     // Если есть сохраненные данные, то вводим их
@@ -90,28 +121,29 @@ function onDoModal(dlgInfo)
                     dlgInfo.cancel = true   // Отменяем показ диалога
                     dlgInfo.result = 1      // Как будто в нем нажали Ок
                     if(profileRoot.getValue(pflShowMessage))    // Информируем пользователя, если он хочет
-                        Message("Авто-подключение к хранилищу '" + data.path + "' пользователем '" + data.login + "'")
-                    // Взведем процедуру определения успешности соединения с хранилищем
-                    prevConnectSuccessed = false
-                    events.connect(Designer, "onIdle", SelfScript.self)
+                        Message("Авто-подключение к хранилищу "+repoTitle+" '" + data.path + "' пользователем '" + data.login + "'")
                 }
             }
         }
-        else if(dlgInfo.stage == afterDoModal && dlgInfo.result == 1)
+        else if(dlgInfo.stage == afterDoModal && dlgInfo.result == 1 && dlgInfo.cancel == false)
         {
             // Предложим сохранить введенные данные
             if(MessageBox("Подставлять введенные значения автоматически при последующих подключениях?",
                 mbYesNo | mbDefButton1 | mbIconQuestion) == mbaYes)
             {
                 // Сохраним их
+                var data0 = profileRoot.getValue(pflData);
+                if (!(data0))
+                    data0 = v8New("Соответствие");
                 var data = v8New("Структура", "login,password,path",
                     dlgInfo.form.getControl("UserName").value,
                     dlgInfo.form.getControl("UserPassword").value,
-                    dlgInfo.form.getControl("DepotPath").value)
+                    dlgInfo.form.getControl("DepotPath").value);
+                data0.Вставить(repoParam, data);
                 var currentBasePath = cnnString();
                 profileRoot.createValue(pflData, false, pflBaseUser)    // Храним отдельно для базы/пользователя
                 profileRoot.createValue(pflCurrentBasePath, false, pflBaseUser);
-                profileRoot.setValue(pflData, data)
+                profileRoot.setValue(pflData, data0)
                 profileRoot.setValue(pflCurrentBasePath, currentBasePath)
             }
         }

--- a/addins/stg_autoconnect.js
+++ b/addins/stg_autoconnect.js
@@ -59,7 +59,6 @@ function onDoModal(dlgInfo)
         repoType = (matches[2]=="конфигурации")?1:2;
         repoTitle = matches[2] + ((repoType==1)?"":matches[3]);
         repoParam = (repoType==1)?"Конфигурация":("Расширение:"+matches[3]);
-        Message("Try:"+count+". Stage:"+dlgInfo.stage+". Title:"+repoTitle);
     }
 
     if(repoType)

--- a/addins/stg_autoconnect.js
+++ b/addins/stg_autoconnect.js
@@ -235,6 +235,16 @@ function macrosНастройка() {
 
 (function() {
 	if (stdlib.isConfigOpen()) {
+		var data = profileRoot.getValue(pflData);
+		if (data) {
+			if (toV8Value(data).typeName(1) == "Структура")
+			{
+				data0 = v8New("Соответствие");
+				data0.Вставить("Конфигурация", data);
+				profileRoot.setValue(pflData, data0);
+				Message("Сохранённые данные для входа в хранилище конвертированы в данные входа в хранилище Конфигурации");
+			}
+		}
 		var no = profileRoot.getValue(pflAutoOpenCfgStore);
 		if (profileRoot.getValue(pflAutoOpenCfgStore)) {
 			var s = stdcommands.CfgStore.OpenCfgStore.getState();

--- a/engine/controls.as
+++ b/engine/controls.as
@@ -327,7 +327,7 @@ class IDoModalHook {
         return _view is null ? "" : _view.title().str;
     }
     IV8Form&& get_form() {
-        if (_form is null) {
+        if (_form is null && !(_view is null)) {
             IForm&& f = _view.unk;
             if (f !is null)
                 &&_form = IV8Form(f);


### PR DESCRIPTION
Доработан скрипт для https://github.com/infostart-hub/snegopat/issues/93.
Перед тестированием необходимо сбросить сохраненные данные скрипта.
Плюс поправлен вылет, если диалог, на который хук поставлен не содержит view.

реализация  #

Настройки сохраняются в соответствие с именами расширений.
Немного изменил логику отлова диалогов - окна расширений перед показом имеют старый заголовок, пришлось ловить перед открытием.

@infostart-hub/snegopat - просьба прокомментировать и проверить
